### PR TITLE
Fix runtime error in evaluation script

### DIFF
--- a/eval/gpt_eval.py
+++ b/eval/gpt_eval.py
@@ -70,7 +70,9 @@ Predicted Answer: {prediction}
         reference_ans = "; ".join(reference_ans_ori)
         # print(reference_ans)
     else:
-        kill
+        raise ValueError(
+            f"Unsupported type for reference_ans_ori: {type(reference_ans_ori)}"
+        )
 
     if reference_ans ==False:
         reference_ans="no"


### PR DESCRIPTION
## Summary
- fix undefined variable reference in `gpt_eval.py`

## Testing
- `python3 -m py_compile eval/gpt_eval.py`
- `find . -name "*.py" -not -path "./data/*" -not -path "./sft/data/*" | xargs -I {} python3 -m py_compile {}`

------
https://chatgpt.com/codex/tasks/task_e_68445e2bec9c832796d10185841dc1d2