### PR TITLE
Add credibility tracking for search results

### DIFF
--- a/bing_persian_medical_search.py
+++ b/bing_persian_medical_search.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import requests
+from inference.credibility import mark_results
 
 persian_medical_thesaurus = {
     "فشار خون بالا": ["هایپرتانسیون", "پرفشاری خون", "افزایش فشار خون"],
@@ -45,7 +46,9 @@ def search_term(term: str, api_key: str = None, count: int = 5):
     synonyms = persian_medical_thesaurus.get(term)
     query_terms = synonyms if synonyms is not None else [term]
     query = " ".join(query_terms)
-    return bing_search(query, api_key, count)
+    results = bing_search(query, api_key, count)
+    mark_results(results)
+    return results
 
 
 if __name__ == "__main__":

--- a/data/website_credibility.json
+++ b/data/website_credibility.json
@@ -1,0 +1,162 @@
+[
+    {
+        "Rank": 1,
+        "Website Name": "Ministry of Health, Treatment & Medical Education",
+        "URL": "behdasht.gov.ir",
+        "Credibility Score (/100)": 98,
+        "Primary Focus/Type": "Governmental Health Authority",
+        "Key Strengths Summary": "Official national health policies, public health data, medical education oversight, highest authority"
+    },
+    {
+        "Rank": 2,
+        "Website Name": "WHO Eastern Mediterranean Regional Office (Iran)",
+        "URL": "emro.who.int/countries/iran/index.html",
+        "Credibility Score (/100)": 97,
+        "Primary Focus/Type": "International Health Organization",
+        "Key Strengths Summary": "Global health standards, regional health information, evidence-based guidelines, high objectivity"
+    },
+    {
+        "Rank": 3,
+        "Website Name": "Tehran University of Medical Sciences (TUMS)",
+        "URL": "tums.ac.ir",
+        "Credibility Score (/100)": 95,
+        "Primary Focus/Type": "Academic Medical Institution, Research",
+        "Key Strengths Summary": "Leading medical university, extensive research output, expert faculty, educational resources"
+    },
+    {
+        "Rank": 4,
+        "Website Name": "Scientific Information Database (SID)",
+        "URL": "sid.ir",
+        "Credibility Score (/100)": 92,
+        "Primary Focus/Type": "National Research Database",
+        "Key Strengths Summary": "Access to Iranian scientific articles, research papers, promotes evidence-based knowledge"
+    },
+    {
+        "Rank": 5,
+        "Website Name": "Islamic Republic of Iran Medical Council (IRIMC)",
+        "URL": "irimc.org",
+        "Credibility Score (/100)": 90,
+        "Primary Focus/Type": "Professional Medical Regulatory Body",
+        "Key Strengths Summary": "Medical licensing, professional ethics, directory of medical associations, official announcements"
+    },
+    {
+        "Rank": 6,
+        "Website Name": "Shahid Beheshti University of Medical Sciences",
+        "URL": "sbmu.ac.ir",
+        "Credibility Score (/100)": 89,
+        "Primary Focus/Type": "Academic Medical Institution, Research",
+        "Key Strengths Summary": "Prominent medical university, strong research focus, diverse medical faculties, public health services"
+    },
+    {
+        "Rank": 7,
+        "Website Name": "Magiran (Iran's Publications Database)",
+        "URL": "magiran.com",
+        "Credibility Score (/100)": 88,
+        "Primary Focus/Type": "National Research Database",
+        "Key Strengths Summary": "Access to a wide range of Iranian journals including medical, supports research and evidence"
+    },
+    {
+        "Rank": 8,
+        "Website Name": "Iran University of Medical Sciences (IUMS)",
+        "URL": "iums.ac.ir",
+        "Credibility Score (/100)": 87,
+        "Primary Focus/Type": "Academic Medical Institution, Research",
+        "Key Strengths Summary": "Major medical university, contributes to medical education and research, clinical services"
+    },
+    {
+        "Rank": 9,
+        "Website Name": "Shiraz University of Medical Sciences (SUMS)",
+        "URL": "sums.ac.ir",
+        "Credibility Score (/100)": 86,
+        "Primary Focus/Type": "Academic Medical Institution, Research",
+        "Key Strengths Summary": "Established medical university, significant research activities, comprehensive medical programs"
+    },
+    {
+        "Rank": 10,
+        "Website Name": "Isfahan University of Medical Sciences (MUI)",
+        "URL": "mui.ac.ir",
+        "Credibility Score (/100)": 85,
+        "Primary Focus/Type": "Academic Medical Institution, Research",
+        "Key Strengths Summary": "Key medical university, active in research and medical training, regional health impact"
+    },
+    {
+        "Rank": 11,
+        "Website Name": "Tabriz University of Medical Sciences (TBZMED)",
+        "URL": "tbzmed.ac.ir",
+        "Credibility Score (/100)": 84,
+        "Primary Focus/Type": "Academic Medical Institution, Research",
+        "Key Strengths Summary": "Important medical university, focus on medical education, research, and healthcare provision"
+    },
+    {
+        "Rank": 12,
+        "Website Name": "Mashhad University of Medical Sciences (MUMS)",
+        "URL": "mums.ac.ir",
+        "Credibility Score (/100)": 83,
+        "Primary Focus/Type": "Academic Medical Institution, Research",
+        "Key Strengths Summary": "Large medical university, extensive educational programs, research initiatives, and hospital network"
+    },
+    {
+        "Rank": 13,
+        "Website Name": "Iranian General Practitioners Association",
+        "URL": "isgp.ir",
+        "Credibility Score (/100)": 80,
+        "Primary Focus/Type": "Professional Medical Association",
+        "Key Strengths Summary": "Represents general practitioners, provides professional resources, advocates for primary care"
+    },
+    {
+        "Rank": 14,
+        "Website Name": "Iranian Society of Internal Medicine Specialists",
+        "URL": "dakheli.org",
+        "Credibility Score (/100)": 79,
+        "Primary Focus/Type": "Professional Medical Association (Specialized)",
+        "Key Strengths Summary": "Focus on internal medicine, expert-driven content for specialists, conference information"
+    },
+    {
+        "Rank": 15,
+        "Website Name": "Iranian Ophthalmological Society",
+        "URL": "irso.org",
+        "Credibility Score (/100)": 78,
+        "Primary Focus/Type": "Professional Medical Association (Specialized)",
+        "Key Strengths Summary": "Dedicated to ophthalmology, provides information for eye care professionals, patient education resources"
+    },
+    {
+        "Rank": 16,
+        "Website Name": "Salamat News",
+        "URL": "salamatnews.com",
+        "Credibility Score (/100)": 75,
+        "Primary Focus/Type": "Medical News Agency",
+        "Key Strengths Summary": "Dedicated health news, covers wide range of medical topics, reports on health policies"
+    },
+    {
+        "Rank": 17,
+        "Website Name": "BBC Persian - Health Section",
+        "URL": "bbc.com/persian/topics/cvjp23v72z2t",
+        "Credibility Score (/100)": 72,
+        "Primary Focus/Type": "International News Outlet (Health Section)",
+        "Key Strengths Summary": "Reports on global and local health issues, often cites expert sources, broad audience reach"
+    },
+    {
+        "Rank": 18,
+        "Website Name": "Mehr News Agency - Health Section",
+        "URL": "mehrnews.com/service/health",
+        "Credibility Score (/100)": 70,
+        "Primary Focus/Type": "National News Agency (Health Section)",
+        "Key Strengths Summary": "Covers national health news, government announcements, health sector developments"
+    },
+    {
+        "Rank": 19,
+        "Website Name": "Zoomit - Health & Medical",
+        "URL": "zoomit.ir/health-medical/",
+        "Credibility Score (/100)": 68,
+        "Primary Focus/Type": "Technology & Science News (Health Section)",
+        "Key Strengths Summary": "Covers medical technology, research breakthroughs, often translates international science news"
+    },
+    {
+        "Rank": 20,
+        "Website Name": "Paziresh24 Blog",
+        "URL": "paziresh24.com/blog",
+        "Credibility Score (/100)": 60,
+        "Primary Focus/Type": "Commercial Health Service (Informational Blog)",
+        "Key Strengths Summary": "Provides general health articles, associated with an appointment/consultation platform"
+    }
+]

--- a/inference/credibility.py
+++ b/inference/credibility.py
@@ -1,0 +1,62 @@
+import json
+import os
+from urllib.parse import urlparse
+
+
+CREDIBILITY_FILE = os.path.join(os.path.dirname(__file__), '..', 'data', 'website_credibility.json')
+
+
+def _domain(url: str) -> str:
+    parsed = urlparse(url if url.startswith('http') else f'http://{url}')
+    domain = parsed.netloc.lower()
+    if domain.startswith('www.'):
+        domain = domain[4:]
+    return domain
+
+
+def load_scores(path: str = CREDIBILITY_FILE):
+    if os.path.exists(path):
+        with open(path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return []
+
+
+def save_scores(data, path: str = CREDIBILITY_FILE):
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def get_score(url: str, data=None) -> int:
+    domain = _domain(url)
+    data = data or load_scores()
+    for item in data:
+        if _domain(item['URL']) == domain:
+            return item.get('Credibility Score (/100)', 0)
+    return 0
+
+
+def mark_results(results, data=None, url_key='url', score_key='credibility'):
+    data = data or load_scores()
+    for r in results:
+        url = r.get(url_key, '')
+        r[score_key] = get_score(url, data)
+    return results
+
+
+def adjust_score(url: str, delta: int = -1, path: str = CREDIBILITY_FILE):
+    data = load_scores(path)
+    domain = _domain(url)
+    for item in data:
+        if _domain(item['URL']) == domain:
+            item['Credibility Score (/100)'] = max(0, item.get('Credibility Score (/100)', 0) + delta)
+            break
+    else:
+        data.append({
+            'Rank': len(data) + 1,
+            'Website Name': domain,
+            'URL': domain,
+            'Credibility Score (/100)': max(0, delta),
+            'Primary Focus/Type': '',
+            'Key Strengths Summary': ''
+        })
+    save_scores(data, path)

--- a/inference/google_search.py
+++ b/inference/google_search.py
@@ -2,6 +2,7 @@
 import os
 import json
 import requests
+from .credibility import mark_results
 from requests.exceptions import Timeout
 from bs4 import BeautifulSoup
 from tqdm import tqdm
@@ -335,5 +336,6 @@ def extract_relevant_info(search_results):
             useful_info.append(info)
     else:
         print("No organic results found.")
+    useful_info = mark_results(useful_info)
     print(f"len of useful_info: {len(useful_info)}")
     return useful_info


### PR DESCRIPTION
## Summary
- track medical website credibility in `data/website_credibility.json`
- add helper module `inference/credibility.py` to manage credibility scores
- mark search results with credibility info in `google_search.py`
- apply same marking to Persian medical Bing search script

## Testing
- `python -m py_compile inference/credibility.py bing_persian_medical_search.py inference/google_search.py`

------
https://chatgpt.com/codex/tasks/task_e_68448a6692ac8327bebc6feae7fe5266